### PR TITLE
Asserts should not have any code in them because when NDEBUG is defined,

### DIFF
--- a/src/con_x11.cpp
+++ b/src/con_x11.cpp
@@ -2146,7 +2146,10 @@ int GUI::OpenPipe(char *Command, EModel *notify) {
                 signal(SIGPIPE, SIG_DFL);
                 close(pfd[0]);
                 close(0);
-                assert(open("/dev/null", O_RDONLY) == 0);
+                {
+                    int handle = open("/dev/null", O_RDONLY);
+                    assert(handle == 0);
+                }
                 dup2(pfd[1], 1);
                 dup2(pfd[1], 2);
                 close(pfd[1]);

--- a/src/e_mark.cpp
+++ b/src/e_mark.cpp
@@ -262,6 +262,8 @@ int EMarkIndex::PopMark(EView *aView) {
     sprintf(name, "#%d", stackTop);
     if (View(aView, name) == 0)
         return 0;
-    assert(Remove(name) == 1);
+
+    int removed_success = Remove(name);
+    assert(removed_success == 1);
     return 1;
 }

--- a/src/e_unix.cpp
+++ b/src/e_unix.cpp
@@ -53,7 +53,8 @@ int EView::SysShowHelp(ExState &State, const char *word) {
             close(2);
             //dup(1); // ignore error output
             close(0);
-            assert(open("/dev/null", O_RDONLY) == 0);
+            int fh = open("/dev/null", O_RDONLY);
+            assert(fh == 0);
             execlp("man", "man",
 #ifndef AIX // current AIX's don't like the -a.
                    "-a",


### PR DESCRIPTION
assert expressions get compiled entirely away.

I didn't do the OS2 ones because I don't have such a system to compile
with anymore.  (Arguably, OS/2 support could be dropped since IBM stopped
supporting that OS over ten years ago.)