### PR TITLE
Fix for terminals that use 0x7f for backspace

### DIFF
--- a/src/con_ncurses.cpp
+++ b/src/con_ncurses.cpp
@@ -661,6 +661,8 @@ int ConGetEvent(TEventMask /*EventMask */ ,
         KEvent->Code |= kbTab;
     } else if (ch < 32) {
         KEvent->Code |= (kfCtrl | (ch + 0100));
+    } else if (ch == 0x7f) {
+        KEvent->Code = kbBackSp;
     } else if (ch < 256) {
         KEvent->Code |= ch;
     } else { // > 255


### PR DESCRIPTION
Initially I thought this was an issue in FreeBSD but evidently it's quite common for terminals to use 0x7F instead of ^H for backspace, wrongly or rightly:

"The list of terminals that send 0x7F for kbs (both according to terminfo and in practice) includes quite a few terminal emulators still in current use, including linux, st, mlterm-256color, konsole-256color, iTerm.app, iTerm2.app, etc. Many terminals that set TERM=xterm-256color also send 0x7F for Backspace in practice (despite the terminfo entry using kbs=^H)"

- https://gist.github.com/andscoop/874ff042a28ca5aaa06426a58aacaf83