### PR TITLE
Allow negative line numbers to move the cursor

### DIFF
--- a/src/o_buffer.cpp
+++ b/src/o_buffer.cpp
@@ -1024,6 +1024,10 @@ int EBuffer::MoveToLine(ExState &State) {
         if (View->MView->Win->GetStr("Goto Line", sizeof(Num), Num, HIST_POSITION) == 0)
             return 0;
         No = atol(Num);
+        if (No < 0)
+        {
+             No = RCount - abs(No) + 1;
+        }
     }
     return SetNearPosR(CP.Col, No - 1);
 }


### PR DESCRIPTION
Negative line numbers begin from the end of the file:

-1 moves the cursor to the end of the file
-2 moves the cursor a line above the end of the file

etc.

This is consistent with other editors such as Nano, Micro and Midnight Commander's editor.