### PR TITLE
Fix compatiblity with tiling window managers

### DIFF
--- a/src/con_x11.cpp
+++ b/src/con_x11.cpp
@@ -898,8 +898,8 @@ int ConSetSize(int X, int Y) {
     int i;
     int MX, MY;
 
-    assert(X <= ConMaxCols);
-    assert(Y <= ConMaxRows);
+    if (X > ConMaxCols) X = ConMaxCols;
+    if (Y > ConMaxRows) Y = ConMaxRows;
 
     p = NewBuffer = (unsigned char *) malloc(X * Y * 2);
     if (NewBuffer == NULL) return -1;


### PR DESCRIPTION
Tiling window managers can force the window size to be larger than
supported by con_x11, causing either an early abort at ConSetSize,
or if compiled with NDEBUG, a segmentation fault down the road.

Instead, just cap X and Y to their maximums. The only consequence is that
the window is not fully utilised.